### PR TITLE
Load property definitions as they are needed

### DIFF
--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -199,10 +199,26 @@ property_files.forEach(function (property) {
     if (property.substr(-3) === '.js') {
         property = path.basename(property, '.js');
         dashed = camelToDashed(property);
-        definition = require('./properties/' + property).definition;
-        Object.defineProperty(CSSStyleDeclaration.prototype, property, definition);
-        Object.defineProperty(CSSStyleDeclaration.prototype, dashed, definition);
+        Object.defineProperty(CSSStyleDeclaration.prototype, property, new LazyDefinition(property, './properties/' + property));
+        Object.defineProperty(CSSStyleDeclaration.prototype, dashed, new LazyDefinition(property, './properties/' + property));
     }
 });
+
+function LazyDefinition(property, modulePath) {
+  this.get = function() {
+    var definition = require(modulePath).definition;
+    Object.defineProperty(this, property, definition);
+    return this[property];
+  };
+
+  this.set = function(v) {
+    var definition = require(modulePath).definition;
+    Object.defineProperty(this, property, definition);
+    this[property] = v;
+  };
+
+  this.enumerable = true;
+  this.configurable = true;
+}
 
 exports.CSSStyleDeclaration = CSSStyleDeclaration;


### PR DESCRIPTION
We have a tool that loads jsdom (and CSSStyleDeclaration as a consequence) as a dependency.

We run the tool pretty often as part of our dev process so its load time is pretty important to us and I'd imagine others as well.  This change reduces the time to `require('cssstyle')` by about 66%

Here is a little script that will time how long it takes to require cssstyle so you can test this change out:

``` javascript
function timeFn(fn) {
  var start = process.hrtime();

  fn();

  var elapsed = process.hrtime(start);
  var ms = elapsed[1] / 1000000
  console.log(elapsed[0] + 's ' + ms + ' ms');
}

timeFn(function() {
  var cssstyle = require('cssstyle');
});
```

This is a huge win for any scripts that only use a subset of the cssstyle properties.
