### PR TITLE
Fixed css value of 0 (Number)

### DIFF
--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -30,7 +30,8 @@ CSSStyleDeclaration.prototype = {
      * Returns the empty string if the property has not been set.
      */
     getPropertyValue: function (name) {
-        return this._values[name] || "";
+        var value = this._values[name];
+        return value == undefined ? "" : value;
     },
 
     /**


### PR DESCRIPTION
I ran into a problem where some existing web code that now had to be run on the server-side would try to set a property value to the `Number 0` (vs the more correct way of a `String '0'`). I ran into this issue with `fill-opacity` and `stroke-opacity` SVG properties, but this could affect a number of other properties as well. Needless to say, this works fine in browsers. 

The previous code here would evaluate `0` as `false`, which would result in this function returning an empty string as its value. This new value check for undefined should handle both `undefined` and `null` cases, while letting all other values pass through untouched.
