### PR TITLE
Ignore everything except lib

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,3 @@
-node_module
+/*
+!lib/
+!LICENSE


### PR DESCRIPTION
Hi!

When looking at the global size of jsdom, I noticed that cssstyle was packaging a lot of unnecessary things. For instance, the generated coverage (1.2Mb) is included in the package.

Before (v2.0.0):
The generated tgz is 149kb.
The unpacked package is 1.43Mb.

Estimated now:
The generated tgz is 32kb.
The unpackage package is 190Kb.

