### PR TITLE
feat: Implement read/write of custom properties

### DIFF
--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -35,6 +35,9 @@ CSSStyleDeclaration.prototype = {
    * Returns the empty string if the property has not been set.
    */
   getPropertyValue: function(name) {
+    if (name.indexOf('--') === 0 && this.hasOwnProperty(name)) {
+      return this[name];
+    }
     if (!this._values.hasOwnProperty(name)) {
       return '';
     }
@@ -56,13 +59,19 @@ CSSStyleDeclaration.prototype = {
       this.removeProperty(name);
       return;
     }
-    var lowercaseName = name.toLowerCase();
-    if (!allProperties.has(lowercaseName) && !allExtraProperties.has(lowercaseName)) {
+    var isCustomProperty = name.indexOf('--') === 0;
+    // custom properties are case-sensitive
+    var propertyName = isCustomProperty ? name : name.toLowerCase();
+    if (
+      !isCustomProperty &&
+      !allProperties.has(propertyName) &&
+      !allExtraProperties.has(propertyName)
+    ) {
       return;
     }
 
-    this[lowercaseName] = value;
-    this._importants[lowercaseName] = priority;
+    this[propertyName] = value;
+    this._importants[propertyName] = priority;
   },
   _setProperty: function(name, value, priority) {
     if (value === undefined) {

--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -35,9 +35,6 @@ CSSStyleDeclaration.prototype = {
    * Returns the empty string if the property has not been set.
    */
   getPropertyValue: function(name) {
-    if (name.indexOf('--') === 0 && this.hasOwnProperty(name)) {
-      return this[name];
-    }
     if (!this._values.hasOwnProperty(name)) {
       return '';
     }
@@ -60,18 +57,17 @@ CSSStyleDeclaration.prototype = {
       return;
     }
     var isCustomProperty = name.indexOf('--') === 0;
-    // custom properties are case-sensitive
-    var propertyName = isCustomProperty ? name : name.toLowerCase();
-    if (
-      !isCustomProperty &&
-      !allProperties.has(propertyName) &&
-      !allExtraProperties.has(propertyName)
-    ) {
+    if (isCustomProperty) {
+      this._setProperty(name, value, priority);
+      return;
+    }
+    var lowercaseName = name.toLowerCase();
+    if (!allProperties.has(lowercaseName) && !allExtraProperties.has(lowercaseName)) {
       return;
     }
 
-    this[propertyName] = value;
-    this._importants[propertyName] = priority;
+    this[lowercaseName] = value;
+    this._importants[lowercaseName] = priority;
   },
   _setProperty: function(name, value, priority) {
     if (value === undefined) {

--- a/lib/CSSStyleDeclaration.test.js
+++ b/lib/CSSStyleDeclaration.test.js
@@ -537,7 +537,7 @@ describe('CSSStyleDeclaration', () => {
     const style = new CSSStyleDeclaration();
     style['--baz'] = 'yellow';
 
-    expect(style.getPropertyValue('--baz')).toEqual('yellow');
+    expect(style.getPropertyValue('--baz')).toEqual('');
   });
 
   test('custom properties are case-sensitive', () => {

--- a/lib/CSSStyleDeclaration.test.js
+++ b/lib/CSSStyleDeclaration.test.js
@@ -518,4 +518,33 @@ describe('CSSStyleDeclaration', () => {
     expect(0).toEqual(style.length);
     expect(undefined).toEqual(style[0]);
   });
+
+  test('getPropertyValue for custom properties in cssText', () => {
+    const style = new CSSStyleDeclaration();
+    style.cssText = '--foo: red';
+
+    expect(style.getPropertyValue('--foo')).toEqual('red');
+  });
+
+  test('getPropertyValue for custom properties with setProperty', () => {
+    const style = new CSSStyleDeclaration();
+    style.setProperty('--bar', 'blue');
+
+    expect(style.getPropertyValue('--bar')).toEqual('blue');
+  });
+
+  test('getPropertyValue for custom properties with object setter', () => {
+    const style = new CSSStyleDeclaration();
+    style['--baz'] = 'yellow';
+
+    expect(style.getPropertyValue('--baz')).toEqual('yellow');
+  });
+
+  test('custom properties are case-sensitive', () => {
+    const style = new CSSStyleDeclaration();
+    style.cssText = '--fOo: purple';
+
+    expect(style.getPropertyValue('--foo')).toEqual('');
+    expect(style.getPropertyValue('--fOo')).toEqual('purple');
+  });
 });


### PR DESCRIPTION
Part of #89 which is blocking https://github.com/facebook/react/pull/17896.

I did not implement full support since this requires more work and is only partially useful for JSDOM because resolution of values of the css variables requires the cascade. 

Browser behavior: https://codesandbox.io/s/css-custom-properties-access-423ni