### PR TITLE
hide internal props

### DIFF
--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -14,15 +14,13 @@ var getBasicPropertyDescriptor = require('./utils/getBasicPropertyDescriptor');
  * @constructor
  * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleDeclaration
  */
+const D = Object.defineProperty; 
 var CSSStyleDeclaration = function CSSStyleDeclaration(onChangeCallback) {
-  this._values = {};
-  this._importants = {};
-  this._length = 0;
-  this._onChange =
-    onChangeCallback ||
-    function() {
-      return;
-    };
+  // hidden props
+  D(this, '_values', {value: {}, writable: true});
+  D(this, '_importants', {value: {}, writable: true});
+  D(this, '_length', {value: 0, writable: true});
+  D(this, '_onChange', {value: (onChangeCallback || function(){}), writable: true});
 };
 CSSStyleDeclaration.prototype = {
   constructor: CSSStyleDeclaration,
@@ -56,8 +54,8 @@ CSSStyleDeclaration.prototype = {
       this.removeProperty(name);
       return;
     }
-    var isCustomProperty = name.indexOf('--') === 0;
-    if (isCustomProperty) {
+    if (name.slice(0, 2) == '--') {
+      // custom property
       this._setProperty(name, value, priority);
       return;
     }


### PR DESCRIPTION
old:
```js
> JSON.stringify(decl, 0, 2)
{
  _values: { .... },
  _importants: { .... },
  _length: 1234,
  _onChange: function() {},
  '0': 'display',
  '1': 'color'
}
```
new:
```js
> JSON.stringify(decl, 0, 2)
{
  '0': 'display',
  '1': 'color'
}
```