### PR TITLE
bugfix：兼容style中多余的分号

### DIFF
--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -187,6 +187,7 @@ Object.defineProperties(CSSStyleDeclaration.prototype, {
     set: function(value) {
       var i;
       this._values = {};
+      value = value.replace(/;+/gi, ';');
       Array.prototype.splice.call(this, 0, this._length);
       this._importants = {};
       var dummyRule;


### PR DESCRIPTION
如题，浏览器dom渲染多个分号是兼容的，cssdom中会丢失一部分样式