### PR TITLE
fix: ensure priority is set before calling the onchange callback

### DIFF
--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -59,6 +59,7 @@ CSSStyleDeclaration.prototype = {
     var isCustomProperty = name.indexOf('--') === 0;
     if (isCustomProperty) {
       this._setProperty(name, value, priority);
+      this._onChange(this.cssText);
       return;
     }
     var lowercaseName = name.toLowerCase();
@@ -68,6 +69,7 @@ CSSStyleDeclaration.prototype = {
 
     this[lowercaseName] = value;
     this._importants[lowercaseName] = priority;
+    this._onChange(this.cssText);
   },
   _setProperty: function(name, value, priority) {
     if (value === undefined) {
@@ -91,7 +93,6 @@ CSSStyleDeclaration.prototype = {
     }
     this._values[name] = value;
     this._importants[name] = priority;
-    this._onChange(this.cssText);
   },
 
   /**

--- a/lib/CSSStyleDeclaration.test.js
+++ b/lib/CSSStyleDeclaration.test.js
@@ -359,6 +359,20 @@ describe('CSSStyleDeclaration', () => {
     style.setProperty('opacity', 0);
   });
 
+  test('onchange callback should be called when priority is specified on a setProperty call', () => {
+    var style = new CSSStyleDeclaration(function(cssText) {
+      expect(cssText).toEqual('opacity: 0 !important;');
+    });
+    style.setProperty('opacity', 0, 'important');
+  });
+
+  test('onchange callback should be called when custom property is set', () => {
+    var style = new CSSStyleDeclaration(function(cssText) {
+      expect(cssText).toEqual('--test-prop: 0;');
+    });
+    style.setProperty('--test-prop', 0);
+  });
+
   test('setting float should work the same as cssfloat', () => {
     var style = new CSSStyleDeclaration();
     style.float = 'left';


### PR DESCRIPTION
fixes https://github.com/jsdom/jsdom/issues/2649

The `onChange` callback is called prematurely when invoking `setProperty` with an `important` priority. This results in elements wrongly being assigned an inline style attribute value without `!important`. Setting multiple important properties in jsdom results in the last one assigned missing `!important`:

```js
const el = document.createElement('div');
el.style.setProperty('opacity', '0', 'important');
el.style.setProperty('width', '0', 'important');
el.getAttribute('style'); // `opacity: 0 !important; width: 0;` 
```