### PR TITLE
Allow removing indiviual margin/padding properties

### DIFF
--- a/lib/CSSStyleDeclaration.test.js
+++ b/lib/CSSStyleDeclaration.test.js
@@ -415,7 +415,44 @@ describe('CSSStyleDeclaration', () => {
           }
         }
       }
-  });
+    }
+  );
+
+  test.each(['margin', 'padding'])(
+    'setting additional %s properties keeps important status of others',
+    (property) => {
+      var style = new CSSStyleDeclaration();
+      var importantProperty = property + '-top: 3px !important;';
+      style.cssText = importantProperty;
+      expect(style.cssText).toContain(importantProperty);
+
+      style[property + 'Right'] = '4px';
+      style[property + 'Bottom'] = '5px';
+      style[property + 'Left'] = '6px';
+
+      expect(style.cssText).toContain(importantProperty);
+      expect(style.cssText).toContain(property + '-right: 4px;');
+      expect(style.cssText).toContain(property + '-bottom: 5px;');
+      expect(style.cssText).toContain(property + '-left: 6px;');
+      expect(style.cssText).not.toContain('margin:');
+    }
+  );
+
+  test.each(['margin', 'padding'])(
+    'setting individual %s keeps important status of others',
+    (property) => {
+      var style = new CSSStyleDeclaration();
+      style.cssText = property + ': 3px !important;';
+
+      style[property + 'Top'] = '4px';
+
+      expect(style.cssText).toContain(property + '-top: 4px;');
+      expect(style.cssText).toContain(property + '-right: 3px !important;');
+      expect(style.cssText).toContain(property + '-bottom: 3px !important;');
+      expect(style.cssText).toContain(property + '-left: 3px !important;');
+      expect(style.cssText).not.toContain('margin:');
+    }
+  );
 
   test('setting a value to 0 should return the string value', () => {
     var style = new CSSStyleDeclaration();

--- a/lib/CSSStyleDeclaration.test.js
+++ b/lib/CSSStyleDeclaration.test.js
@@ -363,6 +363,60 @@ describe('CSSStyleDeclaration', () => {
     }
   });
 
+  test('removing and setting individual margin properties updates the combined property accordingly', () => {
+    var style = new CSSStyleDeclaration();
+    style.margin = '1px 2px 3px 4px';
+
+    style.marginTop = '';
+    expect(style.margin).toEqual('');
+    expect(style.marginRight).toEqual('2px');
+    expect(style.marginBottom).toEqual('3px');
+    expect(style.marginLeft).toEqual('4px');
+
+    style.marginBottom = '';
+    expect(style.margin).toEqual('');
+    expect(style.marginRight).toEqual('2px');
+    expect(style.marginLeft).toEqual('4px');
+
+    style.marginBottom = '5px';
+    expect(style.margin).toEqual('');
+    expect(style.marginRight).toEqual('2px');
+    expect(style.marginBottom).toEqual('5px');
+    expect(style.marginLeft).toEqual('4px');
+
+    style.marginTop = '6px';
+    expect(style.cssText).toEqual('margin: 6px 2px 5px 4px;');
+  });
+
+  test.each(['padding', 'margin'])(
+    'removing an individual %s property should remove the combined property and replace it with the remaining individual ones',
+    (property) => {
+      var style = new CSSStyleDeclaration();
+      var parts = ['Top', 'Right', 'Bottom', 'Left'];
+      var partValues = ['1px', '2px', '3px', '4px'];
+
+      for (var j = 0; j < parts.length; j++) {
+        var partToRemove = parts[j];
+        style[property] = partValues.join(' ');
+        style[property + partToRemove] = '';
+
+        // Main property should have been removed
+        expect(style[property]).toEqual('');
+
+        // Expect other parts to still be there
+        for (var k = 0; k < parts.length; k++) {
+          var propertyCss = property + '-' + parts[k].toLowerCase() + ': ' + partValues[k] + ';';
+          if (k === j) {
+            expect(style[property + parts[k]]).toEqual('');
+            expect(style.cssText).not.toContain(propertyCss);
+          } else {
+            expect(style[property + parts[k]]).toEqual(partValues[k]);
+            expect(style.cssText).toContain(propertyCss);
+          }
+        }
+      }
+  });
+
   test('setting a value to 0 should return the string value', () => {
     var style = new CSSStyleDeclaration();
     style.setProperty('fill-opacity', 0);

--- a/lib/CSSStyleDeclaration.test.js
+++ b/lib/CSSStyleDeclaration.test.js
@@ -346,6 +346,23 @@ describe('CSSStyleDeclaration', () => {
     testParts('margin', '1px 2px 3px 4px', 'auto');
   });
 
+  test('setting individual padding and margin properties to an empty string should clear them', () => {
+    var style = new CSSStyleDeclaration();
+
+    var properties = ['padding', 'margin'];
+    var parts = ['Top', 'Right', 'Bottom', 'Left'];
+    for (var i = 0; i < properties.length; i++) {
+      for (var j = 0; j < parts.length; j++) {
+        var property = properties[i] + parts[j];
+        style[property] = '12px';
+        expect(style[property]).toEqual('12px');
+
+        style[property] = '';
+        expect(style[property]).toEqual('');
+      }
+    }
+  });
+
   test('setting a value to 0 should return the string value', () => {
     var style = new CSSStyleDeclaration();
     style.setProperty('fill-opacity', 0);

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -692,17 +692,26 @@ exports.subImplicitSetter = function (prefix, part, isValid, parser) {
     v = parser(v);
     this._setProperty(property, v);
 
-    var parts = subparts.map(subpart => this._values[subpart]);
-    if (parts.every(p => p !== '' && p != null)) {
+    var combinedPriority = this.getPropertyPriority(prefix);
+    var parts = subparts.map((subpart) => this._values[subpart]);
+    var priorities = subparts.map((subpart) => this.getPropertyPriority(subpart));
+    // Combine into a single property if all values are set and have the same priority
+    if (
+      parts.every((p) => p !== '' && p != null) &&
+      priorities.every((p) => p === priorities[0]) &&
+      priorities[0] === combinedPriority
+    ) {
       for (var i = 0; i < subparts.length; i++) {
         this.removeProperty(subparts[i]);
         this._values[subparts[i]] = parts[i];
       }
-      this._setProperty(prefix, parts.join(' '));
+      this._setProperty(prefix, parts.join(' '), priorities[0]);
     } else {
       this.removeProperty(prefix);
-      for (var i = 0; i < subparts.length; i++) {
-        this._setProperty(subparts[i], parts[i]);
+      for (var j = 0; j < subparts.length; j++) {
+        // The property we're setting won't be important, the rest will either keep their priority or inherit it from the combined property
+        var priority = subparts[j] === property ? '' : priorities[j] || combinedPriority;
+        this._setProperty(subparts[j], parts[j], priority);
       }
     }
     return v;

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -691,19 +691,19 @@ exports.subImplicitSetter = function (prefix, part, isValid, parser) {
     }
     v = parser(v);
     this._setProperty(property, v);
-    var parts = [];
-    for (var i = 0; i < 4; i++) {
-      if (this._values[subparts[i]] == null || this._values[subparts[i]] === '') {
-        break;
-      }
-      parts.push(this._values[subparts[i]]);
-    }
-    if (parts.length === 4) {
-      for (i = 0; i < 4; i++) {
+
+    var parts = subparts.map(subpart => this._values[subpart]);
+    if (parts.every(p => p !== '' && p != null)) {
+      for (var i = 0; i < subparts.length; i++) {
         this.removeProperty(subparts[i]);
         this._values[subparts[i]] = parts[i];
       }
       this._setProperty(prefix, parts.join(' '));
+    } else {
+      this.removeProperty(prefix);
+      for (var i = 0; i < subparts.length; i++) {
+        this._setProperty(subparts[i], parts[i]);
+      }
     }
     return v;
   };

--- a/lib/properties/margin.js
+++ b/lib/properties/margin.js
@@ -9,6 +9,7 @@ var isValid = function (v) {
   }
   var type = parsers.valueType(v);
   return (
+    type === TYPES.NULL_OR_EMPTY_STR ||
     type === TYPES.LENGTH ||
     type === TYPES.PERCENT ||
     (type === TYPES.INTEGER && (v === '0' || v === 0))

--- a/lib/properties/padding.js
+++ b/lib/properties/padding.js
@@ -6,6 +6,7 @@ var TYPES = parsers.TYPES;
 var isValid = function (v) {
   var type = parsers.valueType(v);
   return (
+    type === TYPES.NULL_OR_EMPTY_STR ||
     type === TYPES.LENGTH ||
     type === TYPES.PERCENT ||
     (type === TYPES.INTEGER && (v === '0' || v === 0))


### PR DESCRIPTION
This should fix https://github.com/jsdom/jsdom/issues/3372 by allowing to set properties like `marginTop` to an empty string.