### PR TITLE
perf: skip unnecessary access to cssText property

### DIFF
--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -18,11 +18,7 @@ var CSSStyleDeclaration = function CSSStyleDeclaration(onChangeCallback) {
   this._values = {};
   this._importants = {};
   this._length = 0;
-  this._onChange =
-    onChangeCallback ||
-    function () {
-      return;
-    };
+  this._onChange = onChangeCallback;
 };
 CSSStyleDeclaration.prototype = {
   constructor: CSSStyleDeclaration,
@@ -91,7 +87,9 @@ CSSStyleDeclaration.prototype = {
     }
     this._values[name] = value;
     this._importants[name] = priority;
-    this._onChange(this.cssText);
+    if (this._onChange) {
+      this._onChange(this.cssText);
+    }
   },
 
   /**
@@ -121,7 +119,9 @@ CSSStyleDeclaration.prototype = {
     // That's what Firefox does
     //this[index] = ""
 
-    this._onChange(this.cssText);
+    if (this._onChange) {
+      this._onChange(this.cssText);
+    }
     return prevValue;
   },
 
@@ -206,7 +206,9 @@ Object.defineProperties(CSSStyleDeclaration.prototype, {
           dummyRule.getPropertyPriority(name)
         );
       }
-      this._onChange(this.cssText);
+      if (this._onChange) {
+        this._onChange(this.cssText);
+      }
     },
     enumerable: true,
     configurable: true,


### PR DESCRIPTION
While investigating slow tests in my project written with React + Chakra UI, I found out that calling the get accessor of `cssText` property takes up a large portion of total execution time. This PR is to skip such calls when possible by making `_onChange` calls conditional.

In my project, I saw ~40% improvement of the execution time (24sec → 15sec).