### PR TITLE
Re-do the recent performance fix

### DIFF
--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -74,7 +74,12 @@ CSSStyleDeclaration.prototype = {
       this.removeProperty(name);
       return;
     }
-    var originalText = this.cssText;
+
+    var originalText;
+    if (this._onChange) {
+      originalText = this.cssText;
+    }
+
     if (this._values[name]) {
       // Property already exist. Overwrite it.
       var index = Array.prototype.indexOf.call(this, name);


### PR DESCRIPTION
180cab17ece0cd3db23a26464eff39038a354a7a removed unnecessary access to the cssText property when there is no onChange callback provided. However, 1f5940b2759605f890039764380b553fad855816 undid that gain by saving the original value for later comparison.