### PR TITLE
Add calc support for margin and padding

### DIFF
--- a/lib/properties/margin.js
+++ b/lib/properties/margin.js
@@ -12,6 +12,7 @@ var isValid = function (v) {
     type === TYPES.NULL_OR_EMPTY_STR ||
     type === TYPES.LENGTH ||
     type === TYPES.PERCENT ||
+    type === TYPES.CALC ||
     (type === TYPES.INTEGER && (v === '0' || v === 0))
   );
 };

--- a/lib/properties/padding.js
+++ b/lib/properties/padding.js
@@ -9,6 +9,7 @@ var isValid = function (v) {
     type === TYPES.NULL_OR_EMPTY_STR ||
     type === TYPES.LENGTH ||
     type === TYPES.PERCENT ||
+    type === TYPES.CALC ||
     (type === TYPES.INTEGER && (v === '0' || v === 0))
   );
 };

--- a/test/CSSStyleDeclaration.js
+++ b/test/CSSStyleDeclaration.js
@@ -727,9 +727,19 @@ describe('CSSStyleDeclaration', () => {
     assert.strictEqual(style.getPropertyValue('--fOo'), 'purple');
   });
 
-  it('supports calc', () => {
-    const style = new CSSStyleDeclaration();
-    style.setProperty('width', 'calc(100% - 100px)');
-    assert.strictEqual(style.getPropertyValue('width'), 'calc(100% - 100px)');
-  });
+  for (const property of [
+    'width',
+    'height',
+    'margin',
+    'margin-top',
+    'bottom',
+    'right',
+    'padding',
+  ]) {
+    it(`supports calc for ${property}`, () => {
+      const style = new CSSStyleDeclaration();
+      style.setProperty(property, 'calc(100% - 100px)');
+      assert.strictEqual(style.getPropertyValue(property), 'calc(100% - 100px)');
+    });
+  }
 });


### PR DESCRIPTION
Add support for `calc` for `margin` and `padding`. Other properties such as `width`, `top`, ... already support calc.

More properties should support `calc`, but I haven't included them all in this PR:
- `background-position: calc(100% - 0%) calc(100% - 10%)`. Not included because `parse` function splits on whitespace, but whitespace can also occur inside calc parentheses.
- `border-bottom-width` (and other "length" types): uses `parseLength` (from `parsers.js`), didn't want to change because too many usages. It could be done though, for example `parseMeasurement` already allows `calc`.

This PR should fix https://github.com/jsdom/cssstyle/issues/154