### PR TITLE
fix: upgrade @asamuzakjp/css-color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.2.1",
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^2.8.2",
+        "@asamuzakjp/css-color": "^3.0.12",
         "rrweb-cssom": "^0.8.0"
       },
       "devDependencies": {
@@ -30,16 +30,16 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-2.8.2.tgz",
-      "integrity": "sha512-RtWv9jFN2/bLExuZgFFZ0I3pWWeezAHGgrmjqGGWclATl1aDe3yhCUaI0Ilkp6OCk9zX7+FjvDasEX8Q9Rxc5w==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.0.12.tgz",
+      "integrity": "sha512-pjiqCzOm3L2YbDGrCwZm3fiank8DFsu0Qidi70sx6XqAob/UvE14bd80BDsy3z9/e+BupDzu052K0Qb6/LcYKQ==",
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^2.1.1",
         "@csstools/css-color-parser": "^3.0.7",
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
-        "lru-cache": "^11.0.2"
+        "lru-cache": "^10.4.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2219,13 +2219,10 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
-      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
-      }
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "main": "./lib/CSSStyleDeclaration.js",
   "dependencies": {
-    "@asamuzakjp/css-color": "^2.8.2",
+    "@asamuzakjp/css-color": "^3.0.12",
     "rrweb-cssom": "^0.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
https://github.com/asamuzaK/cssColor/releases/tag/v3.0.0 migrated to a new bundling and exports setup, with the intention of improving CJS/ESM/TS compatibility.

Before: https://publint.dev/@asamuzakjp/css-color@2.8.2
After: https://publint.dev/@asamuzakjp/css-color@3.0.0

This PR bumps the version range for `@asamuzakjp/css-color` to include the v3 releases.

Fixes #182