### PR TITLE
Raise minimum Node.js version to v20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 18
           - 20
+          - lts/*
           - latest
     steps:
     - uses: actions/checkout@v4

--- a/lib/properties/font.js
+++ b/lib/properties/font.js
@@ -76,8 +76,7 @@ module.exports.parse = function parse(v) {
       return;
     }
   } else {
-    // FIXME: Switch to toReversed() when we can drop Node.js 18 support.
-    const revParts = [...parsers.splitValue(fontBlockA.trim())].reverse();
+    const revParts = parsers.splitValue(fontBlockA.trim()).toReversed();
     const revFontFamily = [];
     const properties = ["font-style", "font-variant", "font-weight", "line-height"];
     font["font-style"] = "normal";

--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   }
 }

--- a/scripts/generateImplementedProperties.mjs
+++ b/scripts/generateImplementedProperties.mjs
@@ -1,16 +1,16 @@
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { camelCaseToDashed } from "../lib/utils/camelize.js";
 
+const { dirname } = import.meta;
 const dashedProperties = fs
-  .readdirSync(resolve("../lib/properties"))
+  .readdirSync(path.resolve(dirname, "../lib/properties"))
   .filter((propertyFile) => path.extname(propertyFile) === ".js")
   .map((propertyFile) => camelCaseToDashed(path.basename(propertyFile, ".js")));
 
-const outputFile = resolve("../lib/generated/implementedProperties.js");
+const outputFile = path.resolve(dirname, "../lib/generated/implementedProperties.js");
 
-const propertyNamesJSON = JSON.stringify(dashedProperties, undefined, 2);
+const propertyNamesJSON = JSON.stringify(dashedProperties.toSorted(), undefined, 2);
 const dateToday = new Date();
 const [dateTodayFormatted] = dateToday.toISOString().split("T");
 const output = `"use strict";
@@ -21,8 +21,3 @@ module.exports = new Set(${propertyNamesJSON});
 `;
 
 fs.writeFileSync(outputFile, output);
-
-// TODO: remove when we can drop Node.js 18 support and use import.meta.dirname.
-function resolve(relativePath) {
-  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), relativePath);
-}


### PR DESCRIPTION
* `.github/workflows/build.yml`
  Drop node v18 and add node v22 as `lts/*`
* `package.json`
  Bump `engines.node` to `>=20`
* `lib/properties/font.js`
  Switch to Array.prototype.toReversed()
* `scripts/generateImplementedProperties.mjs`
  * Switch to `import.meta.dirname`
  * Sort generated properties

<ins>Done below</ins>

TODO:
Fix `properties/font.js` after #227 get merged.

TBD:
Should we fix `scripts/generateImplementedProperties.mjs` too?
However, `import.meta.dirname` is not standard.
