### PR TITLE
set cssText: avoid serializing cssText when not needed

### DIFF
--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -391,7 +391,7 @@ Object.defineProperties(CSSStyleDeclaration.prototype, {
         return;
       }
       let originalText = "";
-      if (typeof this._onChange === "function") {
+      if (typeof this._onChange === "function" && !this._setInProgress) {
         originalText = this.cssText;
       }
       if (this._values.has(property)) {
@@ -414,8 +414,8 @@ Object.defineProperties(CSSStyleDeclaration.prototype, {
       this._values.set(property, val);
       if (
         typeof this._onChange === "function" &&
-        this.cssText !== originalText &&
-        !this._setInProgress
+        !this._setInProgress &&
+        this.cssText !== originalText
       ) {
         this._onChange(this.cssText);
       }


### PR DESCRIPTION
Fixes https://github.com/jsdom/jsdom/issues/3985, at least a big part of it.

During `set cssText` the library calls `setProperty` many times but wants to fire the `onChange` callback only once at the end. That's what the `this._setInProgress` field is for. But despite `_setInProgress` being `true`, the `get cssText` getter is called many times: to get the `originalText`, and because of suboptimal order of conditions.

This patch helps avoid these unneeded and expensive `get cssText` calls. They are expensive because they serialize the AST structure to a string.

I've been testing this on a little JSDOM benchmark script:
```js
console.time('create-100-divs');
for (let i = 0; i < 100; i++) {
  const div = document.createElement('div');
  div.style.cssText = 'color: blue; background-color: white; padding: 10px; border: 1px solid black;';
  div.textContent = `Div #${i + 1}`;
  document.body.appendChild(div);
}
console.timeEnd('create-100-divs');
```

Before this PR, it takes 230ms to execute, after this PR it's 130ms, almost 2x improvement.

I think there are going to be even more optimization opportunities. If I remove the `div.style.cssText` assignment, the whole loop runs in 1ms.