### PR TITLE
Remove dependenciesComments from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,6 @@
     "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
     "css-tree": "^3.1.0"
   },
-  "//dependenciesComments": {
-    "@csstools/css-syntax-patches-for-csstree": "pinned at 1.0.14 for now due to https://github.com/jsdom/cssstyle/issues/256"
-  },
   "devDependencies": {
     "@babel/generator": "^7.28.5",
     "@babel/parser": "^7.28.5",


### PR DESCRIPTION
Deleted the dependenciesComments section related to @csstools/css-syntax-patches-for-csstree, as it is no longer needed.