### PR TITLE
Clean up package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-/*
-!lib/
-!LICENSE

--- a/package.json
+++ b/package.json
@@ -1,36 +1,15 @@
 {
   "name": "cssstyle",
-  "description": "CSSStyleDeclaration Object Model implementation",
+  "description": "An implementation of the CSSStyleDeclaration class from the CSS Object Model specification",
   "keywords": [
     "CSS",
     "CSSStyleDeclaration",
     "StyleSheet"
   ],
   "version": "5.3.5",
-  "homepage": "https://github.com/jsdom/cssstyle",
-  "maintainers": [
-    {
-      "name": "Jon Sakas",
-      "email": "jon.sakas@gmail.com",
-      "url": "https://jon.sakas.co/"
-    },
-    {
-      "name": "Rafał Ruciński",
-      "email": "fatfisz@gmail.com",
-      "url": "https://fatfisz.com"
-    }
-  ],
-  "contributors": [
-    {
-      "name": "Chad Walker",
-      "email": "chad@chad-cat-lore-eddie.com",
-      "url": "https://github.com/chad3814"
-    }
-  ],
-  "repository": "jsdom/cssstyle",
-  "bugs": "https://github.com/jsdom/cssstyle/issues",
-  "directories": {
-    "lib": "./lib"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jsdom/cssstyle.git"
   },
   "files": [
     "lib/"


### PR DESCRIPTION
* Expand the "description" field.
* Update "repository" to the modern format, per complaints from the npm CLI.
* Remove "homepage" and "bugs", as they can be inferred from "repository".
* Remove "maintainers", as that is set by npm automatically.
* Remove "contributors", as it was outdated and that data is better tracked on GitHub anyway.
* Remove "directories", since an entry for the "lib" directory does nothing.
* Remove the .npmignore file, since it's redundant with the package.json "files" field.