### PR TITLE
fix: replace object shorthand to fix Rollup parse error

### DIFF
--- a/lib/properties/font.js
+++ b/lib/properties/font.js
@@ -47,7 +47,8 @@ module.exports.parse = function parse(v, opt = {}) {
       return;
     }
     const lineHeightB = lineHeight.parse(lineB, {
-      global
+      // eslint-disable-next-line object-shorthand
+      global: global
     });
     if (typeof lineHeightB !== "string") {
       return;


### PR DESCRIPTION
When using **jsdom** in a **Svelte 5** environment, the build fails due to a syntax error in **cssstyle**.

I added jsdom to a Svelte 5 project and only used the following minimal code:

```js
import { JSDOM } from "jsdom";

const dom = new JSDOM();

console.log(dom);
```

However, running `vite build` results in the following error:

```
✗ Build failed in 10.75s
error during build:
[vite-plugin-sveltekit-compile] [commonjs] node_modules/.pnpm/cssstyle@5.3.5/node_modules/cssstyle/lib/generated/properties.js (4759:0): Unexpected token `.`. Expected ... , *,  (, [, :, , ?, = or an identifier
file: D:/Svelte/cssstyle-test/node_modules/.pnpm/cssstyle@5.3.5/node_modules/cssstyle/lib/generated/properties.js:4759:0 (D:/Svelte/cssstyle-test/node_modules/.pnpm/jsdom@27.3.0/node_modules/jsdom/lib/jsdom/living/nodes/SVGDefsElement-impl.js)

4757:       definition: lineHeight_export_definition
4758:     }.parse(lineB, {
4759:       global
      ^
4760:     });
4761:     if (typeof lineHeightB !== "string") {

    at getRollupError (file:///D:/Svelte/cssstyle-test/node_modules/.pnpm/rollup@4.54.0/node_modules/rollup/dist/es/shared/parseAst.js:401:41)
    at ParseError.initialise (file:///D:/Svelte/cssstyle-test/node_modules/.pnpm/rollup@4.54.0/node_modules/rollup/dist/es/shared/node-entry.js:14534:28)       
    at convertNode (file:///D:/Svelte/cssstyle-test/node_modules/.pnpm/rollup@4.54.0/node_modules/rollup/dist/es/shared/node-entry.js:16418:10)
    at convertProgram (file:///D:/Svelte/cssstyle-test/node_modules/.pnpm/rollup@4.54.0/node_modules/rollup/dist/es/shared/node-entry.js:15658:12)
    at Module.setSource (file:///D:/Svelte/cssstyle-test/node_modules/.pnpm/rollup@4.54.0/node_modules/rollup/dist/es/shared/node-entry.js:17418:24)
    at async ModuleLoader.addModuleSource (file:///D:/Svelte/cssstyle-test/node_modules/.pnpm/rollup@4.54.0/node_modules/rollup/dist/es/shared/node-entry.js:21448:13)
```

This error originates from the following object literal in `font.js`
```js
{
  global
}
```

The shorthand property syntax (`{ global }`) is not correctly handled by Rollup in this build setup, which causes the parser to throw a syntax error during bundling.

Replacing the shorthand property with an explicit key-value pair resolves the issue:
```js
{
  global: global
}
```
After applying this change, `vite build` completes successfully in the Svelte 5 environment.