### PR TITLE
Refactor property descriptor logic

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -61,7 +61,6 @@ const SYS_COLORS = new Set([
 ]);
 
 // AST node types
-// TODO: Export and use in properties/*.js in the future
 const AST_TYPES = Object.freeze({
   CALC: "Calc",
   DIMENSION: "Dimension",
@@ -639,22 +638,23 @@ const parseGradient = (val) => {
 };
 
 module.exports = {
-  prepareValue,
-  isGlobalKeyword,
-  hasVarFunc,
+  AST_TYPES,
   hasCalcFunc,
-  splitValue,
-  parseCSS,
+  hasVarFunc,
+  isGlobalKeyword,
   isValidPropertyValue,
-  resolveCalc,
-  parsePropertyValue,
-  parseNumber,
-  parseLength,
-  parsePercentage,
-  parseLengthPercentage,
   parseAngle,
-  parseUrl,
-  parseString,
+  parseCSS,
   parseColor,
-  parseGradient
+  parseGradient,
+  parseLength,
+  parseLengthPercentage,
+  parseNumber,
+  parsePercentage,
+  parsePropertyValue,
+  parseString,
+  parseUrl,
+  prepareValue,
+  resolveCalc,
+  splitValue
 };

--- a/lib/utils/propertyDescriptors.js
+++ b/lib/utils/propertyDescriptors.js
@@ -2,18 +2,50 @@
 
 const parsers = require("../parsers");
 
-exports.getPropertyDescriptor = function getPropertyDescriptor(property) {
-  return {
-    set(v) {
-      v = parsers.parsePropertyValue(property, v, {
-        globalObject: this._global
+const { AST_TYPES } = parsers;
+
+const getPropertyDescriptor = (property) => ({
+  set(v) {
+    const value = parsers.prepareValue(v, this._global);
+    if (parsers.hasVarFunc(value)) {
+      this._setProperty(property, value);
+    } else {
+      const parsedValue = parsers.parsePropertyValue(property, v, {
+        globalObject: this._global,
+        inArray: true
       });
-      this._setProperty(property, v);
-    },
-    get() {
-      return this.getPropertyValue(property);
-    },
-    enumerable: true,
-    configurable: true
-  };
+      if (Array.isArray(parsedValue)) {
+        if (parsedValue.length === 1) {
+          const [{ name, type }] = parsedValue;
+          switch (type) {
+            case AST_TYPES.GLOBAL_KEYWORD:
+            case AST_TYPES.IDENTIFIER: {
+              // Set the normalized name for keywords or identifiers.
+              this._setProperty(property, name);
+              break;
+            }
+            default: {
+              // Set the prepared value for Calc, Dimension, etc.
+              this._setProperty(property, value);
+            }
+          }
+        } else {
+          // Set the prepared value for lists containing multiple values.
+          this._setProperty(property, value);
+        }
+      } else if (typeof parsedValue === "string") {
+        // Empty string.
+        this._setProperty(property, parsedValue);
+      }
+    }
+  },
+  get() {
+    return this.getPropertyValue(property);
+  },
+  enumerable: true,
+  configurable: true
+});
+
+module.exports = {
+  getPropertyDescriptor
 };


### PR DESCRIPTION
Exports AST_TYPES from parsers.js and refactors getPropertyDescriptor in propertyDescriptors.js to improve value normalization and handling of parsed property values. The new logic distinguishes between variable functions, keywords, identifiers, and other value types for more accurate property setting.

With this fix, test:tuwpt css/cssom/serialize-whitespace.html will pass.
