### PR TITLE
Ensure _setInProgress is safely reset using try-finally

### DIFF
--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -174,8 +174,8 @@ class CSSStyleDeclaration {
     if (this._parentRule || (this._ownerNode && this._setInProgress)) {
       return;
     }
-    this._setInProgress = true;
     try {
+      this._setInProgress = true;
       const valueObj = parseCSS(
         val,
         {
@@ -246,8 +246,9 @@ class CSSStyleDeclaration {
       }
     } catch {
       return;
+    } finally {
+      this._setInProgress = false;
     }
-    this._setInProgress = false;
     if (typeof this._onChange === "function") {
       this._onChange(this.cssText);
     }


### PR DESCRIPTION
### Summary

This PR improves the robustness of the `cssText` setter by wrapping the `_setInProgress` flag management in a `try-finally` block.

### Details

Previously, `this._setInProgress` was modified/reset outside of the try-catch block. This approach is potentially error-prone; if an error occurs during parsing or execution, the flag might not be reset correctly, leaving the object in an inconsistent state.

By moving the reset logic into a `finally` block, we guarantee that `_setInProgress` is always set back to `false`, regardless of whether an exception is thrown or not.

See also: https://github.com/jsdom/cssstyle/pull/244#discussion_r2583923242
