### PR TITLE
Remove unnecessary arguments

### DIFF
--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -350,7 +350,7 @@ class CSSStyleDeclaration {
       const name = "NoModificationAllowedError";
       throw new this._global.DOMException(msg, name);
     }
-    const value = prepareValue(val, this._global);
+    const value = prepareValue(val);
     if (value === "") {
       this[prop] = "";
       this.removeProperty(prop);

--- a/lib/properties/background.js
+++ b/lib/properties/background.js
@@ -247,7 +247,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (v === "" || parsers.hasVarFunc(v)) {
       for (const [key] of module.exports.shorthandFor) {
         this._setProperty(key, "");

--- a/lib/properties/backgroundAttachment.js
+++ b/lib/properties/backgroundAttachment.js
@@ -34,7 +34,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/backgroundClip.js
+++ b/lib/properties/backgroundClip.js
@@ -34,7 +34,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/backgroundColor.js
+++ b/lib/properties/backgroundColor.js
@@ -23,7 +23,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/backgroundImage.js
+++ b/lib/properties/backgroundImage.js
@@ -36,7 +36,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/backgroundOrigin.js
+++ b/lib/properties/backgroundOrigin.js
@@ -34,7 +34,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/backgroundPosition.js
+++ b/lib/properties/backgroundPosition.js
@@ -177,7 +177,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/backgroundRepeat.js
+++ b/lib/properties/backgroundRepeat.js
@@ -66,7 +66,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/backgroundSize.js
+++ b/lib/properties/backgroundSize.js
@@ -99,7 +99,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/border.js
+++ b/lib/properties/border.js
@@ -84,7 +84,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/borderBottom.js
+++ b/lib/properties/borderBottom.js
@@ -74,7 +74,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/borderBottomColor.js
+++ b/lib/properties/borderBottomColor.js
@@ -25,7 +25,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/borderBottomStyle.js
+++ b/lib/properties/borderBottomStyle.js
@@ -25,7 +25,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/borderBottomWidth.js
+++ b/lib/properties/borderBottomWidth.js
@@ -28,7 +28,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/borderCollapse.js
+++ b/lib/properties/borderCollapse.js
@@ -22,7 +22,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/borderColor.js
+++ b/lib/properties/borderColor.js
@@ -84,7 +84,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/borderLeft.js
+++ b/lib/properties/borderLeft.js
@@ -74,7 +74,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/borderLeftColor.js
+++ b/lib/properties/borderLeftColor.js
@@ -25,7 +25,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/borderLeftStyle.js
+++ b/lib/properties/borderLeftStyle.js
@@ -25,7 +25,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/borderLeftWidth.js
+++ b/lib/properties/borderLeftWidth.js
@@ -28,7 +28,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/borderRight.js
+++ b/lib/properties/borderRight.js
@@ -74,7 +74,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/borderRightColor.js
+++ b/lib/properties/borderRightColor.js
@@ -25,7 +25,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/borderRightStyle.js
+++ b/lib/properties/borderRightStyle.js
@@ -25,7 +25,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/borderRightWidth.js
+++ b/lib/properties/borderRightWidth.js
@@ -28,7 +28,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/borderSpacing.js
+++ b/lib/properties/borderSpacing.js
@@ -42,7 +42,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/borderStyle.js
+++ b/lib/properties/borderStyle.js
@@ -84,7 +84,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/borderTop.js
+++ b/lib/properties/borderTop.js
@@ -74,7 +74,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/borderTopColor.js
+++ b/lib/properties/borderTopColor.js
@@ -25,7 +25,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/borderTopStyle.js
+++ b/lib/properties/borderTopStyle.js
@@ -25,7 +25,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/borderTopWidth.js
+++ b/lib/properties/borderTopWidth.js
@@ -28,7 +28,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/borderWidth.js
+++ b/lib/properties/borderWidth.js
@@ -85,7 +85,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._borderSetter(property, v, "");
     } else {

--- a/lib/properties/bottom.js
+++ b/lib/properties/bottom.js
@@ -24,7 +24,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/clear.js
+++ b/lib/properties/clear.js
@@ -22,7 +22,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/clip.js
+++ b/lib/properties/clip.js
@@ -50,7 +50,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/color.js
+++ b/lib/properties/color.js
@@ -22,7 +22,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/display.js
+++ b/lib/properties/display.js
@@ -187,7 +187,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/flex.js
+++ b/lib/properties/flex.js
@@ -142,7 +142,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       for (const [longhand] of module.exports.shorthandFor) {
         this._setProperty(longhand, "");

--- a/lib/properties/flexBasis.js
+++ b/lib/properties/flexBasis.js
@@ -25,7 +25,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/flexGrow.js
+++ b/lib/properties/flexGrow.js
@@ -25,7 +25,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/flexShrink.js
+++ b/lib/properties/flexShrink.js
@@ -25,7 +25,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/float.js
+++ b/lib/properties/float.js
@@ -22,7 +22,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/floodColor.js
+++ b/lib/properties/floodColor.js
@@ -22,7 +22,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/font.js
+++ b/lib/properties/font.js
@@ -243,7 +243,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (v === "" || parsers.hasVarFunc(v)) {
       for (const [key] of module.exports.shorthandFor) {
         this._setProperty(key, "");

--- a/lib/properties/fontFamily.js
+++ b/lib/properties/fontFamily.js
@@ -71,7 +71,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/fontSize.js
+++ b/lib/properties/fontSize.js
@@ -26,7 +26,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/fontStyle.js
+++ b/lib/properties/fontStyle.js
@@ -42,7 +42,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/fontVariant.js
+++ b/lib/properties/fontVariant.js
@@ -39,7 +39,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/fontWeight.js
+++ b/lib/properties/fontWeight.js
@@ -30,7 +30,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/height.js
+++ b/lib/properties/height.js
@@ -25,7 +25,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/left.js
+++ b/lib/properties/left.js
@@ -24,7 +24,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/lightingColor.js
+++ b/lib/properties/lightingColor.js
@@ -22,7 +22,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/lineHeight.js
+++ b/lib/properties/lineHeight.js
@@ -25,7 +25,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/margin.js
+++ b/lib/properties/margin.js
@@ -51,7 +51,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       for (const [longhand] of module.exports.shorthandFor) {
         this._setProperty(longhand, "");

--- a/lib/properties/marginBottom.js
+++ b/lib/properties/marginBottom.js
@@ -27,7 +27,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/marginLeft.js
+++ b/lib/properties/marginLeft.js
@@ -27,7 +27,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/marginRight.js
+++ b/lib/properties/marginRight.js
@@ -27,7 +27,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/marginTop.js
+++ b/lib/properties/marginTop.js
@@ -27,7 +27,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/opacity.js
+++ b/lib/properties/opacity.js
@@ -24,7 +24,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/outlineColor.js
+++ b/lib/properties/outlineColor.js
@@ -22,7 +22,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/padding.js
+++ b/lib/properties/padding.js
@@ -52,7 +52,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       for (const [longhand] of module.exports.shorthandFor) {
         this._setProperty(longhand, "");

--- a/lib/properties/paddingBottom.js
+++ b/lib/properties/paddingBottom.js
@@ -28,7 +28,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/paddingLeft.js
+++ b/lib/properties/paddingLeft.js
@@ -28,7 +28,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/paddingRight.js
+++ b/lib/properties/paddingRight.js
@@ -28,7 +28,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/paddingTop.js
+++ b/lib/properties/paddingTop.js
@@ -28,7 +28,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(shorthand, "");
       this._setProperty(property, v);

--- a/lib/properties/right.js
+++ b/lib/properties/right.js
@@ -24,7 +24,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/stopColor.js
+++ b/lib/properties/stopColor.js
@@ -22,7 +22,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/top.js
+++ b/lib/properties/top.js
@@ -25,7 +25,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/webkitBorderAfterColor.js
+++ b/lib/properties/webkitBorderAfterColor.js
@@ -22,7 +22,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/webkitBorderBeforeColor.js
+++ b/lib/properties/webkitBorderBeforeColor.js
@@ -22,7 +22,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/webkitBorderEndColor.js
+++ b/lib/properties/webkitBorderEndColor.js
@@ -22,7 +22,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/webkitBorderStartColor.js
+++ b/lib/properties/webkitBorderStartColor.js
@@ -22,7 +22,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/webkitColumnRuleColor.js
+++ b/lib/properties/webkitColumnRuleColor.js
@@ -22,7 +22,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/webkitTapHighlightColor.js
+++ b/lib/properties/webkitTapHighlightColor.js
@@ -22,7 +22,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/webkitTextEmphasisColor.js
+++ b/lib/properties/webkitTextEmphasisColor.js
@@ -22,7 +22,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/webkitTextFillColor.js
+++ b/lib/properties/webkitTextFillColor.js
@@ -22,7 +22,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/webkitTextStrokeColor.js
+++ b/lib/properties/webkitTextStrokeColor.js
@@ -22,7 +22,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/properties/width.js
+++ b/lib/properties/width.js
@@ -25,7 +25,7 @@ module.exports.parse = (v, opt = {}) => {
 
 module.exports.definition = {
   set(v) {
-    v = parsers.prepareValue(v, this._global);
+    v = parsers.prepareValue(v);
     if (parsers.hasVarFunc(v)) {
       this._setProperty(property, v);
     } else {

--- a/lib/utils/propertyDescriptors.js
+++ b/lib/utils/propertyDescriptors.js
@@ -6,7 +6,7 @@ const { AST_TYPES } = parsers;
 
 const getPropertyDescriptor = (property) => ({
   set(v) {
-    const value = parsers.prepareValue(v, this._global);
+    const value = parsers.prepareValue(v);
     if (parsers.hasVarFunc(value)) {
       this._setProperty(property, value);
     } else {


### PR DESCRIPTION
Follow up for https://github.com/jsdom/cssstyle/pull/275

Removed 2nd arg, i.e. this._global, from prepareValue().
