### PR TITLE
perf: Add property-to-index Map for O(1) lookups in _getIndexOf

### DIFF
--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -50,6 +50,7 @@ class CSSStyleDeclaration {
     this._length = 0;
     this._priorities = new Map();
     this._values = new Map();
+    this._propertyIndices = new Map(); // Maps property name -> index for O(1) lookups
 
     if (context) {
       if (typeof context.getComputedStyle === "function") {
@@ -121,6 +122,7 @@ class CSSStyleDeclaration {
     this._removeIndexedProperties(0, this._length);
     this._values.clear();
     this._priorities.clear();
+    this._propertyIndices.clear();
     if (this._parentRule || (this._ownerNode && this._updating)) {
       return;
     }
@@ -355,10 +357,15 @@ class CSSStyleDeclaration {
    */
   _removeIndexedProperties(index, count) {
     const length = this._length;
-    // Shift subsequent properties.
-    // Will be skipped if count === length.
+    // Remove the properties being deleted from the index map
+    for (let i = index; i < index + count && i < length; i++) {
+      this._propertyIndices.delete(this[i]);
+    }
+    // Shift subsequent properties and update their indices
     for (let i = index; i < length - count; i++) {
-      this[i] = this[i + count];
+      const prop = this[i + count];
+      this[i] = prop;
+      this._propertyIndices.set(prop, i);
     }
     // Delete properties at the end.
     for (let i = length - count; i < length; i++) {
@@ -375,12 +382,8 @@ class CSSStyleDeclaration {
    * @returns {number} The index of the property, or -1 if not found.
    */
   _getIndexOf(property) {
-    for (let i = 0; i < this._length; i++) {
-      if (this[i] === property) {
-        return i;
-      }
-    }
-    return -1;
+    const index = this._propertyIndices.get(property);
+    return index !== undefined ? index : -1;
   }
 
   /**
@@ -406,6 +409,7 @@ class CSSStyleDeclaration {
     if (!this._values.has(property)) {
       // New property.
       this[this._length] = property;
+      this._propertyIndices.set(property, this._length);
       this._length++;
     }
     if (priority === "important") {


### PR DESCRIPTION
Replaces the O(n) linear search in _getIndexOf with an O(1) Map lookup. The _propertyIndices Map is maintained alongside the indexed properties to track each property's position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To-do before merging:
- [ ] Human code review (@asamuzaK welcome to help)
- [ ] Double-check benchmark improvements manually
- [ ] Double-check the full jsdom test suite passes