### PR TITLE
perf: Fix parsePropertyValue cache to include inArray parameter

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -265,15 +265,11 @@ const parsePropertyValue = (prop, val, opt = {}) => {
     }
     val = calculatedValue;
   }
-  const cacheKey = `parsePropertyValue_${prop}_${val}_${caseSensitive}`;
+  const cacheKey = `parsePropertyValue_${prop}_${val}_${caseSensitive}_${inArray}`;
   const cachedValue = lruCache.get(cacheKey);
   if (cachedValue === false) {
     return;
-  } else if (inArray) {
-    if (Array.isArray(cachedValue)) {
-      return cachedValue;
-    }
-  } else if (typeof cachedValue === "string") {
+  } else if (cachedValue !== undefined) {
     return cachedValue;
   }
   let parsedValue;


### PR DESCRIPTION
The cache key was not including the inArray parameter, which meant that cache entries would be incorrectly reused between calls with different inArray values, causing unnecessary re-parsing.

Since almost all callers use inArray: true, adding it to the cache key significantly improves cache hit rates and overall performance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To-do before merging:
- [ ] Human code review (@asamuzaK welcome to help)
- [ ] Double-check benchmark improvements manually
- [ ] Double-check the full jsdom test suite passes