### PR TITLE
perf: Always return arrays from parsePropertyValue

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -252,7 +252,7 @@ const resolveCalc = (val, opt = { format: "specifiedValue" }) => {
  * @returns {string|Array<object>|undefined} The parsed value.
  */
 const parsePropertyValue = (prop, val, opt = {}) => {
-  const { caseSensitive, inArray } = opt;
+  const { caseSensitive } = opt;
   val = prepareValue(val);
   if (val === "" || hasVarFunc(val)) {
     return val;
@@ -269,38 +269,26 @@ const parsePropertyValue = (prop, val, opt = {}) => {
   const cachedValue = lruCache.get(cacheKey);
   if (cachedValue === false) {
     return;
-  } else if (inArray) {
-    if (Array.isArray(cachedValue)) {
-      return cachedValue;
-    }
-  } else if (typeof cachedValue === "string") {
+  } else if (cachedValue !== undefined) {
     return cachedValue;
   }
   let parsedValue;
   const lowerCasedValue = asciiLowercase(val);
   if (GLOBAL_KEYS.has(lowerCasedValue)) {
-    if (inArray) {
+    parsedValue = [
+      {
+        type: AST_TYPES.GLOBAL_KEYWORD,
+        name: lowerCasedValue
+      }
+    ];
+  } else if (SYS_COLORS.has(lowerCasedValue)) {
+    if (/^(?:(?:-webkit-)?(?:[a-z][a-z\d]*-)*color|border)$/i.test(prop)) {
       parsedValue = [
         {
-          type: AST_TYPES.GLOBAL_KEYWORD,
+          type: AST_TYPES.IDENTIFIER,
           name: lowerCasedValue
         }
       ];
-    } else {
-      parsedValue = lowerCasedValue;
-    }
-  } else if (SYS_COLORS.has(lowerCasedValue)) {
-    if (/^(?:(?:-webkit-)?(?:[a-z][a-z\d]*-)*color|border)$/i.test(prop)) {
-      if (inArray) {
-        parsedValue = [
-          {
-            type: AST_TYPES.IDENTIFIER,
-            name: lowerCasedValue
-          }
-        ];
-      } else {
-        parsedValue = lowerCasedValue;
-      }
     } else {
       parsedValue = false;
     }
@@ -312,7 +300,7 @@ const parsePropertyValue = (prop, val, opt = {}) => {
       const { error, matched } = cssTree.lexer.matchProperty(prop, ast);
       if (error || !matched) {
         parsedValue = false;
-      } else if (inArray) {
+      } else {
         const obj = cssTree.toPlainObject(ast);
         const items = obj.children;
         const values = [];
@@ -391,8 +379,6 @@ const parsePropertyValue = (prop, val, opt = {}) => {
           }
         }
         parsedValue = values;
-      } else {
-        parsedValue = val;
       }
     } catch {
       parsedValue = false;

--- a/lib/properties/backgroundAttachment.js
+++ b/lib/properties/backgroundAttachment.js
@@ -14,8 +14,7 @@ module.exports.parse = (v, opt = {}) => {
   const parsedValues = [];
   for (const val of values) {
     const value = parsers.parsePropertyValue(property, val, {
-      globalObject,
-      inArray: true
+      globalObject
     });
     if (Array.isArray(value) && value.length === 1) {
       const parsedValue = parsers.resolveKeywordValue(value);

--- a/lib/properties/backgroundClip.js
+++ b/lib/properties/backgroundClip.js
@@ -14,8 +14,7 @@ module.exports.parse = (v, opt = {}) => {
   const parsedValues = [];
   for (const val of values) {
     const value = parsers.parsePropertyValue(property, val, {
-      globalObject,
-      inArray: true
+      globalObject
     });
     if (Array.isArray(value) && value.length === 1) {
       const parsedValue = parsers.resolveKeywordValue(value);

--- a/lib/properties/backgroundColor.js
+++ b/lib/properties/backgroundColor.js
@@ -11,8 +11,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveColorValue(value);

--- a/lib/properties/backgroundImage.js
+++ b/lib/properties/backgroundImage.js
@@ -14,8 +14,7 @@ module.exports.parse = (v, opt = {}) => {
   const parsedValues = [];
   for (const val of values) {
     const value = parsers.parsePropertyValue(property, val, {
-      globalObject,
-      inArray: true
+      globalObject
     });
     if (Array.isArray(value) && value.length === 1) {
       const parsedValue = parsers.resolveGradientUrlValue(value);

--- a/lib/properties/backgroundOrigin.js
+++ b/lib/properties/backgroundOrigin.js
@@ -14,8 +14,7 @@ module.exports.parse = (v, opt = {}) => {
   const parsedValues = [];
   for (const val of values) {
     const value = parsers.parsePropertyValue(property, val, {
-      globalObject,
-      inArray: true
+      globalObject
     });
     if (Array.isArray(value) && value.length === 1) {
       const parsedValue = parsers.resolveKeywordValue(value);

--- a/lib/properties/backgroundPosition.js
+++ b/lib/properties/backgroundPosition.js
@@ -22,8 +22,7 @@ module.exports.parse = (v, opt = {}) => {
   const parsedValues = [];
   for (const val of values) {
     const value = parsers.parsePropertyValue(property, val, {
-      globalObject,
-      inArray: true
+      globalObject
     });
     if (Array.isArray(value) && value.length) {
       const [part1, part2, part3, part4] = value;

--- a/lib/properties/backgroundRepeat.js
+++ b/lib/properties/backgroundRepeat.js
@@ -17,8 +17,7 @@ module.exports.parse = (v, opt = {}) => {
   const parsedValues = [];
   for (const val of values) {
     const value = parsers.parsePropertyValue(property, val, {
-      globalObject,
-      inArray: true
+      globalObject
     });
     if (Array.isArray(value) && value.length) {
       let parsedValue = "";

--- a/lib/properties/backgroundSize.js
+++ b/lib/properties/backgroundSize.js
@@ -17,8 +17,7 @@ module.exports.parse = (v, opt = {}) => {
   const parsedValues = [];
   for (const val of values) {
     const value = parsers.parsePropertyValue(property, val, {
-      globalObject,
-      inArray: true
+      globalObject
     });
     if (Array.isArray(value) && value.length) {
       if (value.length === 1) {

--- a/lib/properties/border.js
+++ b/lib/properties/border.js
@@ -45,8 +45,7 @@ module.exports.parse = (v, opt = {}) => {
   const parsedValues = new Map();
   for (const val of values) {
     const value = parsers.parsePropertyValue(property, val, {
-      globalObject,
-      inArray: true
+      globalObject
     });
     if (Array.isArray(value) && value.length === 1) {
       const parsedValue = parsers.resolveBorderShorthandValue(value, subProps, parsedValues);

--- a/lib/properties/borderBlockEndColor.js
+++ b/lib/properties/borderBlockEndColor.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveColorValue(value);

--- a/lib/properties/borderBlockStartColor.js
+++ b/lib/properties/borderBlockStartColor.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveColorValue(value);

--- a/lib/properties/borderBottom.js
+++ b/lib/properties/borderBottom.js
@@ -35,8 +35,7 @@ module.exports.parse = (v, opt = {}) => {
   const parsedValues = new Map();
   for (const val of values) {
     const value = parsers.parsePropertyValue(property, val, {
-      globalObject,
-      inArray: true
+      globalObject
     });
     if (Array.isArray(value) && value.length === 1) {
       const parsedValue = parsers.resolveBorderShorthandValue(value, subProps, parsedValues);

--- a/lib/properties/borderBottomColor.js
+++ b/lib/properties/borderBottomColor.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveColorValue(value);

--- a/lib/properties/borderBottomStyle.js
+++ b/lib/properties/borderBottomStyle.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveKeywordValue(value);

--- a/lib/properties/borderBottomWidth.js
+++ b/lib/properties/borderBottomWidth.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/borderCollapse.js
+++ b/lib/properties/borderCollapse.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveKeywordValue(value);

--- a/lib/properties/borderColor.js
+++ b/lib/properties/borderColor.js
@@ -22,8 +22,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const values = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   const parsedValues = [];
   if (Array.isArray(values) && values.length) {

--- a/lib/properties/borderInlineEndColor.js
+++ b/lib/properties/borderInlineEndColor.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveColorValue(value);

--- a/lib/properties/borderInlineStartColor.js
+++ b/lib/properties/borderInlineStartColor.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveColorValue(value);

--- a/lib/properties/borderLeft.js
+++ b/lib/properties/borderLeft.js
@@ -35,8 +35,7 @@ module.exports.parse = (v, opt = {}) => {
   const parsedValues = new Map();
   for (const val of values) {
     const value = parsers.parsePropertyValue(property, val, {
-      globalObject,
-      inArray: true
+      globalObject
     });
     if (Array.isArray(value) && value.length === 1) {
       const parsedValue = parsers.resolveBorderShorthandValue(value, subProps, parsedValues);

--- a/lib/properties/borderLeftColor.js
+++ b/lib/properties/borderLeftColor.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveColorValue(value);

--- a/lib/properties/borderLeftStyle.js
+++ b/lib/properties/borderLeftStyle.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveKeywordValue(value);

--- a/lib/properties/borderLeftWidth.js
+++ b/lib/properties/borderLeftWidth.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/borderRight.js
+++ b/lib/properties/borderRight.js
@@ -35,8 +35,7 @@ module.exports.parse = (v, opt = {}) => {
   const parsedValues = new Map();
   for (const val of values) {
     const value = parsers.parsePropertyValue(property, val, {
-      globalObject,
-      inArray: true
+      globalObject
     });
     if (Array.isArray(value) && value.length === 1) {
       const parsedValue = parsers.resolveBorderShorthandValue(value, subProps, parsedValues);

--- a/lib/properties/borderRightColor.js
+++ b/lib/properties/borderRightColor.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveColorValue(value);

--- a/lib/properties/borderRightStyle.js
+++ b/lib/properties/borderRightStyle.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveKeywordValue(value);

--- a/lib/properties/borderRightWidth.js
+++ b/lib/properties/borderRightWidth.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/borderSpacing.js
+++ b/lib/properties/borderSpacing.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length) {
     switch (value.length) {

--- a/lib/properties/borderStyle.js
+++ b/lib/properties/borderStyle.js
@@ -22,8 +22,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const values = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   const parsedValues = [];
   if (Array.isArray(values) && values.length) {

--- a/lib/properties/borderTop.js
+++ b/lib/properties/borderTop.js
@@ -35,8 +35,7 @@ module.exports.parse = (v, opt = {}) => {
   const parsedValues = new Map();
   for (const val of values) {
     const value = parsers.parsePropertyValue(property, val, {
-      globalObject,
-      inArray: true
+      globalObject
     });
     if (Array.isArray(value) && value.length === 1) {
       const parsedValue = parsers.resolveBorderShorthandValue(value, subProps, parsedValues);

--- a/lib/properties/borderTopColor.js
+++ b/lib/properties/borderTopColor.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveColorValue(value);

--- a/lib/properties/borderTopStyle.js
+++ b/lib/properties/borderTopStyle.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveKeywordValue(value);

--- a/lib/properties/borderTopWidth.js
+++ b/lib/properties/borderTopWidth.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/borderWidth.js
+++ b/lib/properties/borderWidth.js
@@ -22,8 +22,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const values = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   const parsedValues = [];
   if (Array.isArray(values) && values.length) {

--- a/lib/properties/bottom.js
+++ b/lib/properties/bottom.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/clear.js
+++ b/lib/properties/clear.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveKeywordValue(value);

--- a/lib/properties/clip.js
+++ b/lib/properties/clip.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
   }
   const { AST_TYPES } = parsers;
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     const [{ name, type, value: itemValue }] = value;

--- a/lib/properties/color.js
+++ b/lib/properties/color.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveColorValue(value);

--- a/lib/properties/display.js
+++ b/lib/properties/display.js
@@ -15,8 +15,7 @@ module.exports.parse = (v, opt = {}) => {
   }
   const { AST_TYPES } = parsers;
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length) {
     switch (value.length) {

--- a/lib/properties/flex.js
+++ b/lib/properties/flex.js
@@ -26,8 +26,7 @@ module.exports.parse = (v, opt = {}) => {
   }
   const { AST_TYPES } = parsers;
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length) {
     const flex = {

--- a/lib/properties/flexBasis.js
+++ b/lib/properties/flexBasis.js
@@ -11,8 +11,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/flexGrow.js
+++ b/lib/properties/flexGrow.js
@@ -11,8 +11,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue("flex-grow", v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/flexShrink.js
+++ b/lib/properties/flexShrink.js
@@ -11,8 +11,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/float.js
+++ b/lib/properties/float.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveKeywordValue(value);

--- a/lib/properties/floodColor.js
+++ b/lib/properties/floodColor.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveColorValue(value);

--- a/lib/properties/font.js
+++ b/lib/properties/font.js
@@ -127,8 +127,7 @@ module.exports.parse = (v, opt = {}) => {
     if (revParts.length === 1) {
       const [part] = revParts;
       const value = parsers.parsePropertyValue(property, part, {
-        globalObject,
-        inArray: true
+        globalObject
       });
       if (Array.isArray(value) && value.length === 1) {
         const [{ name, type }] = value;

--- a/lib/properties/fontFamily.js
+++ b/lib/properties/fontFamily.js
@@ -18,8 +18,7 @@ module.exports.parse = (v, opt = {}) => {
   for (const val of values) {
     const value = parsers.parsePropertyValue(property, val, {
       globalObject,
-      caseSensitive: true,
-      inArray: true
+      caseSensitive: true
     });
     if (Array.isArray(value) && value.length) {
       if (value.length === 1) {

--- a/lib/properties/fontSize.js
+++ b/lib/properties/fontSize.js
@@ -11,8 +11,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/fontStyle.js
+++ b/lib/properties/fontStyle.js
@@ -12,8 +12,7 @@ module.exports.parse = (v, opt = {}) => {
   }
   const { AST_TYPES } = parsers;
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length) {
     if (value.length === 1) {

--- a/lib/properties/fontVariant.js
+++ b/lib/properties/fontVariant.js
@@ -14,8 +14,7 @@ module.exports.parse = (v, opt = {}) => {
   const parsedValues = [];
   for (const val of values) {
     const value = parsers.parsePropertyValue(property, val, {
-      globalObject,
-      inArray: true
+      globalObject
     });
     if (Array.isArray(value) && value.length === 1) {
       const parsedValue = parsers.resolveFunctionValue(value);

--- a/lib/properties/fontWeight.js
+++ b/lib/properties/fontWeight.js
@@ -11,8 +11,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     const parsedValue = parsers.resolveNumericValue(value, {

--- a/lib/properties/height.js
+++ b/lib/properties/height.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/left.js
+++ b/lib/properties/left.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/lightingColor.js
+++ b/lib/properties/lightingColor.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveColorValue(value);

--- a/lib/properties/lineHeight.js
+++ b/lib/properties/lineHeight.js
@@ -11,8 +11,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/margin.js
+++ b/lib/properties/margin.js
@@ -23,8 +23,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const values = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   const parsedValues = [];
   if (Array.isArray(values) && values.length) {

--- a/lib/properties/marginBottom.js
+++ b/lib/properties/marginBottom.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/marginLeft.js
+++ b/lib/properties/marginLeft.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/marginRight.js
+++ b/lib/properties/marginRight.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/marginTop.js
+++ b/lib/properties/marginTop.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/opacity.js
+++ b/lib/properties/opacity.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/outlineColor.js
+++ b/lib/properties/outlineColor.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveColorValue(value);

--- a/lib/properties/padding.js
+++ b/lib/properties/padding.js
@@ -23,8 +23,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const values = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   const parsedValues = [];
   if (Array.isArray(values) && values.length) {

--- a/lib/properties/paddingBottom.js
+++ b/lib/properties/paddingBottom.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/paddingLeft.js
+++ b/lib/properties/paddingLeft.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/paddingRight.js
+++ b/lib/properties/paddingRight.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/paddingTop.js
+++ b/lib/properties/paddingTop.js
@@ -13,8 +13,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/right.js
+++ b/lib/properties/right.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/stopColor.js
+++ b/lib/properties/stopColor.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveColorValue(value);

--- a/lib/properties/textEmphasisColor.js
+++ b/lib/properties/textEmphasisColor.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveColorValue(value);

--- a/lib/properties/top.js
+++ b/lib/properties/top.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/properties/webkitTextFillColor.js
+++ b/lib/properties/webkitTextFillColor.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveColorValue(value);

--- a/lib/properties/webkitTextStrokeColor.js
+++ b/lib/properties/webkitTextStrokeColor.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveColorValue(value);

--- a/lib/properties/width.js
+++ b/lib/properties/width.js
@@ -10,8 +10,7 @@ module.exports.parse = (v, opt = {}) => {
     return v;
   }
   const value = parsers.parsePropertyValue(property, v, {
-    globalObject,
-    inArray: true
+    globalObject
   });
   if (Array.isArray(value) && value.length === 1) {
     return parsers.resolveNumericValue(value, {

--- a/lib/utils/propertyDescriptors.js
+++ b/lib/utils/propertyDescriptors.js
@@ -11,8 +11,7 @@ const getPropertyDescriptor = (property) => ({
       this._setProperty(property, value);
     } else {
       const parsedValue = parsers.parsePropertyValue(property, v, {
-        globalObject: this._global,
-        inArray: true
+        globalObject: this._global
       });
       if (Array.isArray(parsedValue)) {
         if (parsedValue.length === 1) {

--- a/test/parsers.test.js
+++ b/test/parsers.test.js
@@ -1252,54 +1252,79 @@ describe("parsePropertyValue", () => {
     assert.strictEqual(output, "var(--foo)");
   });
 
-  it("should get string", () => {
+  it("should get array for calc with number result", () => {
     const property = "background-size";
     const value = "calc(3 / 2)";
     const output = parsers.parsePropertyValue(property, value);
-    assert.strictEqual(output, "calc(1.5)");
+    assert.deepEqual(output, [
+      {
+        type: "Calc",
+        isNumber: true,
+        value: "1.5",
+        name: "calc",
+        raw: "calc(1.5)"
+      }
+    ]);
   });
 
-  it("should get string", () => {
+  it("should get array for calc with dimension result", () => {
     const property = "background-size";
     const value = "calc(3em / 2)";
     const output = parsers.parsePropertyValue(property, value);
-    assert.strictEqual(output, "calc(1.5em)");
+    assert.deepEqual(output, [
+      {
+        type: "Calc",
+        isNumber: false,
+        value: "1.5em",
+        name: "calc",
+        raw: "calc(1.5em)"
+      }
+    ]);
   });
 
-  it("should get string", () => {
+  it("should get array for calc with mixed units", () => {
     const property = "background-size";
     const value = "calc(10px + 20%)";
     const output = parsers.parsePropertyValue(property, value);
-    assert.strictEqual(output, "calc(20% + 10px)");
+    assert.deepEqual(output, [
+      {
+        type: "Calc",
+        isNumber: false,
+        value: "20% + 10px",
+        name: "calc",
+        raw: "calc(20% + 10px)"
+      }
+    ]);
   });
 
-  it("should get string", () => {
+  it("should get array for global keyword", () => {
     const property = "color";
     const value = "initial";
     const output = parsers.parsePropertyValue(property, value);
-    assert.strictEqual(output, "initial");
+    assert.deepEqual(output, [
+      {
+        type: "GlobalKeyword",
+        name: "initial"
+      }
+    ]);
   });
 
-  it("should get string", () => {
+  it("should get array for system color", () => {
     const property = "color";
     const value = "CanvasText";
     const output = parsers.parsePropertyValue(property, value);
-    assert.strictEqual(output, "canvastext");
+    assert.deepEqual(output, [
+      {
+        type: "Identifier",
+        name: "canvastext"
+      }
+    ]);
   });
 
-  it("should get string", () => {
+  it("should get array for color name", () => {
     const property = "color";
     const value = "Green";
     const output = parsers.parsePropertyValue(property, value);
-    assert.strictEqual(output, "Green");
-  });
-
-  it("should get array", () => {
-    const property = "color";
-    const value = "Green";
-    const output = parsers.parsePropertyValue(property, value, {
-      inArray: true
-    });
     assert.deepEqual(output, [
       {
         type: "Identifier",
@@ -1308,11 +1333,10 @@ describe("parsePropertyValue", () => {
     ]);
   });
 
-  it("should get string", () => {
+  it("should get array with caseSensitive option", () => {
     const property = "color";
     const value = "Green";
     const output = parsers.parsePropertyValue(property, value, {
-      inArray: true,
       caseSensitive: true
     });
     assert.deepEqual(output, [
@@ -1324,19 +1348,10 @@ describe("parsePropertyValue", () => {
     ]);
   });
 
-  it("should get string", () => {
+  it("should get array for color function", () => {
     const property = "color";
     const value = "color(srgb 0 calc(1 / 2) 0)";
     const output = parsers.parsePropertyValue(property, value);
-    assert.strictEqual(output, "color(srgb 0 calc(1/2) 0)");
-  });
-
-  it("should get array", () => {
-    const property = "color";
-    const value = "color(srgb 0 calc(1 / 2) 0)";
-    const output = parsers.parsePropertyValue(property, value, {
-      inArray: true
-    });
     assert.deepEqual(output, [
       {
         type: "Function",
@@ -1347,12 +1362,10 @@ describe("parsePropertyValue", () => {
     ]);
   });
 
-  it("should get array", () => {
+  it("should get array for rgb function", () => {
     const property = "color";
     const value = "rgb(0 128 0)";
-    const output = parsers.parsePropertyValue(property, value, {
-      inArray: true
-    });
+    const output = parsers.parsePropertyValue(property, value);
     assert.deepEqual(output, [
       {
         type: "Function",
@@ -1363,12 +1376,10 @@ describe("parsePropertyValue", () => {
     ]);
   });
 
-  it("should get array", () => {
+  it("should get array for none keyword", () => {
     const property = "background-image";
     const value = "none";
-    const output = parsers.parsePropertyValue(property, value, {
-      inArray: true
-    });
+    const output = parsers.parsePropertyValue(property, value);
     assert.deepEqual(output, [
       {
         type: "Identifier",
@@ -1377,12 +1388,10 @@ describe("parsePropertyValue", () => {
     ]);
   });
 
-  it("should get array", () => {
+  it("should get array for url", () => {
     const property = "background-image";
     const value = "url(example.png)";
-    const output = parsers.parsePropertyValue(property, value, {
-      inArray: true
-    });
+    const output = parsers.parsePropertyValue(property, value);
     assert.deepEqual(output, [
       {
         type: "Url",
@@ -1392,12 +1401,10 @@ describe("parsePropertyValue", () => {
     ]);
   });
 
-  it("should get array", () => {
+  it("should get array for url with case preserved", () => {
     const property = "background-image";
     const value = "url(Example.png)";
-    const output = parsers.parsePropertyValue(property, value, {
-      inArray: true
-    });
+    const output = parsers.parsePropertyValue(property, value);
     assert.deepEqual(output, [
       {
         type: "Url",
@@ -1407,12 +1414,10 @@ describe("parsePropertyValue", () => {
     ]);
   });
 
-  it("should get array", () => {
+  it("should get array for gradient", () => {
     const property = "background-image";
     const value = "linear-gradient(green, blue)";
-    const output = parsers.parsePropertyValue(property, value, {
-      inArray: true
-    });
+    const output = parsers.parsePropertyValue(property, value);
     assert.deepEqual(output, [
       {
         type: "Function",


### PR DESCRIPTION
The inArray parameter caused cache thrashing: CSSStyleDeclaration.js
called without it (caching strings) while property files called with
inArray: true (expecting arrays). When the cached type didn't match
what a caller needed, it would recompute and overwrite, causing the
next different-type caller to also miss. By always returning arrays,
all callers can share the same cached results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

To-do before merging:
- [x] Human code review (@asamuzaK welcome to help)
- [x] Double-check benchmark improvements manually
- [x] Double-check the full jsdom test suite passes