### PR TITLE
perf: Skip redundant border shorthand expansion during cssText updates

### DIFF
--- a/lib/properties/border.js
+++ b/lib/properties/border.js
@@ -92,7 +92,15 @@ module.exports.definition = {
       });
       if (val || typeof val === "string") {
         const priority = this._priorities.get(property) ?? "";
-        this._borderSetter(property, val, priority);
+        if (this._updating) {
+          const shorthandValue =
+            typeof val === "string"
+              ? val
+              : (Array.isArray(val) ? val : Object.values(val)).join(" ");
+          this._setProperty(property, shorthandValue, priority);
+        } else {
+          this._borderSetter(property, val, priority);
+        }
       }
     }
   },

--- a/lib/properties/borderBottom.js
+++ b/lib/properties/borderBottom.js
@@ -85,7 +85,15 @@ module.exports.definition = {
           !this._priorities.get(shorthand) && this._priorities.has(property)
             ? this._priorities.get(property)
             : "";
-        this._borderSetter(property, val, priority);
+        if (this._updating) {
+          const shorthandValue =
+            typeof val === "string"
+              ? val
+              : (Array.isArray(val) ? val : Object.values(val)).join(" ");
+          this._setProperty(property, shorthandValue, priority);
+        } else {
+          this._borderSetter(property, val, priority);
+        }
       }
     }
   },

--- a/lib/properties/borderColor.js
+++ b/lib/properties/borderColor.js
@@ -95,7 +95,15 @@ module.exports.definition = {
           !this._priorities.get(shorthand) && this._priorities.has(property)
             ? this._priorities.get(property)
             : "";
-        this._borderSetter(property, val, priority);
+        if (this._updating) {
+          const shorthandValue =
+            typeof val === "string"
+              ? val
+              : (Array.isArray(val) ? val : Object.values(val)).join(" ");
+          this._setProperty(property, shorthandValue, priority);
+        } else {
+          this._borderSetter(property, val, priority);
+        }
       }
     }
   },

--- a/lib/properties/borderLeft.js
+++ b/lib/properties/borderLeft.js
@@ -85,7 +85,15 @@ module.exports.definition = {
           !this._priorities.get(shorthand) && this._priorities.has(property)
             ? this._priorities.get(property)
             : "";
-        this._borderSetter(property, val, priority);
+        if (this._updating) {
+          const shorthandValue =
+            typeof val === "string"
+              ? val
+              : (Array.isArray(val) ? val : Object.values(val)).join(" ");
+          this._setProperty(property, shorthandValue, priority);
+        } else {
+          this._borderSetter(property, val, priority);
+        }
       }
     }
   },

--- a/lib/properties/borderRight.js
+++ b/lib/properties/borderRight.js
@@ -85,7 +85,15 @@ module.exports.definition = {
           !this._priorities.get(shorthand) && this._priorities.has(property)
             ? this._priorities.get(property)
             : "";
-        this._borderSetter(property, val, priority);
+        if (this._updating) {
+          const shorthandValue =
+            typeof val === "string"
+              ? val
+              : (Array.isArray(val) ? val : Object.values(val)).join(" ");
+          this._setProperty(property, shorthandValue, priority);
+        } else {
+          this._borderSetter(property, val, priority);
+        }
       }
     }
   },

--- a/lib/properties/borderStyle.js
+++ b/lib/properties/borderStyle.js
@@ -95,7 +95,15 @@ module.exports.definition = {
           !this._priorities.get(shorthand) && this._priorities.has(property)
             ? this._priorities.get(property)
             : "";
-        this._borderSetter(property, val, priority);
+        if (this._updating) {
+          const shorthandValue =
+            typeof val === "string"
+              ? val
+              : (Array.isArray(val) ? val : Object.values(val)).join(" ");
+          this._setProperty(property, shorthandValue, priority);
+        } else {
+          this._borderSetter(property, val, priority);
+        }
       }
     }
   },

--- a/lib/properties/borderTop.js
+++ b/lib/properties/borderTop.js
@@ -85,7 +85,15 @@ module.exports.definition = {
           !this._priorities.get(shorthand) && this._priorities.has(property)
             ? this._priorities.get(property)
             : "";
-        this._borderSetter(property, val, priority);
+        if (this._updating) {
+          const shorthandValue =
+            typeof val === "string"
+              ? val
+              : (Array.isArray(val) ? val : Object.values(val)).join(" ");
+          this._setProperty(property, shorthandValue, priority);
+        } else {
+          this._borderSetter(property, val, priority);
+        }
       }
     }
   },

--- a/lib/properties/borderWidth.js
+++ b/lib/properties/borderWidth.js
@@ -96,7 +96,15 @@ module.exports.definition = {
           !this._priorities.get(shorthand) && this._priorities.has(property)
             ? this._priorities.get(property)
             : "";
-        this._borderSetter(property, val, priority);
+        if (this._updating) {
+          const shorthandValue =
+            typeof val === "string"
+              ? val
+              : (Array.isArray(val) ? val : Object.values(val)).join(" ");
+          this._setProperty(property, shorthandValue, priority);
+        } else {
+          this._borderSetter(property, val, priority);
+        }
       }
     }
   },


### PR DESCRIPTION
When cssText is set, prepareProperties() already expands border shorthands into all their longhand properties. Previously, calling setProperty() on these shorthands would then trigger their property setters, which called _borderSetter() to expand them again - redundant work.

This makes border property setters check the _updating flag (set during cssText operations) and skip _borderSetter() when true. The setters still call parse() to validate and canonicalize the value, then store it directly via _setProperty().

Affected: border, border-width, border-style, border-color, border-top, border-right, border-bottom, border-left

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

```
  Parent commit (without optimization):
  - style/createElement + style.cssText: 221 ops/sec
  - style/innerHTML: divs with inline styles: 198 ops/sec

  With optimization:
  - style/createElement + style.cssText: 360 ops/sec (+63%)
  - style/innerHTML: divs with inline styles: 305 ops/sec (+54%)
```

---

@asamuzaK I am unsure on this one. It adds a good amount of repetitive code, and is subtle and hard to understand. I guess we can probably factor a bit out to reduce the repetition (I might push some commits to try to do that). But I'm still unsure.

The main thing I'm curious about is how this fits with your larger plans in https://github.com/jsdom/cssstyle/issues/255. Do you plan to overhaul these handlers anyway, onto a newer/better architecture? Should we just wait for that? Or would this sort of optimization be valuable longer term?

I also tried to see if this generalizes to other properties besides the border ones, but am not having too much luck so far.